### PR TITLE
More useful THM website citation

### DIFF
--- a/modules/thermal_hydraulics/joss_paper.bib
+++ b/modules/thermal_hydraulics/joss_paper.bib
@@ -82,11 +82,11 @@ url       = {https://doi.org/10.1080/00295450.2020.1826804}
   note = {Revision 7}
 }
 
-@misc{thm_website,
-  title={THM Documentation Website},
-  author={},
+@online{thm_website,
+  title={Thermal Hydraulics Module},
+  author={{Idaho National Laboratory}},
   year={2023},
-  note ={\url{https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html}}
+  url={https://mooseframework.inl.gov/modules/thermal_hydraulics/index.html}
 }
 
 @article{valgrind,


### PR DESCRIPTION
References just displayed "THM Documentation Website (2023)". Not useful.
